### PR TITLE
Fixed display of disabled categories, updated Hungarian translation

### DIFF
--- a/EasyCategorization.sopm
+++ b/EasyCategorization.sopm
@@ -1,16 +1,15 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <otrs_package version="1.0">
     <Name>EasyCategorization</Name>
-	<Version>5.1.2</Version>
+    <Version>5.1.3</Version>
     <Framework>5.0.x</Framework>
     <PackageMerge Name="AgentBOUPriority" TargetVersion="5.0.0" />
     <Vendor>BeOnUp</Vendor>
     <URL>http://www.beonup.com.br/</URL>
     <License>GNU AFFERO GENERAL PUBLIC LICENSE Version 3, November 2007</License>
-	<ChangeLog Version="5.1.2" Date="2017-03-18 13:40:00">Added support to handle ajax requests, code cleanup.</ChangeLog>
-	<Description Lang="pt_BR">Fácil para classificar seus chamados.</Description>
     <Description Lang="en">Easy to classify your tickets.</Description>
     <Description Lang="hu">Egyszerűen kategorizálhatóvá teszi a jegyeit.</Description>
+    <Description Lang="pt_BR">Fácil para classificar seus chamados.</Description>
     <Filelist>
         <File Permission="644" Location="Kernel/Config/Files/EasyCategorization.xml" />
         <File Permission="644" Location="Kernel/Language/hu_EasyCategorization.pm" />
@@ -21,13 +20,13 @@
         <File Permission="644" Location="Kernel/Output/HTML/Templates/Standard/AgentEasyCategorization.tt" />
         <File Permission="644" Location="var/httpd/htdocs/js/Core.Agent.EasyCategorization.js"></File>
     </Filelist>
-	<IntroInstall Type="post" Lang="pt_BR" Title="Obrigado!">
-        Obrigado por escolher o módulo EasyCategorization da BeOnUp!
-    </IntroInstall>
     <IntroInstall Type="post" Lang="en" Title="Thank you!">
         Thank you for choosing the BeOnUp EasyCategorization module!
     </IntroInstall>
     <IntroInstall Type="post" Lang="hu" Title="Köszönjük!">
         Köszönjük, hogy a BeOnUp EasyCategorization modulját választotta!
+    </IntroInstall>
+    <IntroInstall Type="post" Lang="pt_BR" Title="Obrigado!">
+        Obrigado por escolher o módulo EasyCategorization da BeOnUp!
     </IntroInstall>
 </otrs_package>

--- a/Kernel/Config/Files/EasyCategorization.xml
+++ b/Kernel/Config/Files/EasyCategorization.xml
@@ -61,14 +61,14 @@
             </Option>
         </Setting>
     </ConfigItem>
-	<ConfigItem Name="Frontend::Module###EasyCategorizationAJAXHandler" Required="1" Valid="1">
+    <ConfigItem Name="Frontend::Module###EasyCategorizationAJAXHandler" Required="1" Valid="1">
         <Description Translatable="1">Frontend module registration for the agent interface.</Description>
         <Group>EasyCategorization</Group>
         <SubGroup>Frontend::Agent::ModuleRegistration</SubGroup>
         <Setting>
             <FrontendModuleReg>
-                <Description>To perform easy categorization with AJAX-request</Description>
-                <Title>EasyCategorization AJAX</Title>
+                <Description Translatable="1">To perform easy categorization with AJAX-request.</Description>
+                <Title Translatable="1">EasyCategorization AJAX</Title>
                 <NavBarName></NavBarName>
             </FrontendModuleReg>
         </Setting>

--- a/Kernel/Language/hu_EasyCategorization.pm
+++ b/Kernel/Language/hu_EasyCategorization.pm
@@ -1,7 +1,7 @@
 # --
 # Kernel/Language/hu_EasyCategorization.pm - the Hungarian translation for EasyCategorization
-# Copyright (C) 2015-2016 BeOnUp http://www.beonup.com.br
-# Copyright (C) 2016 Balázs Úr, http://www.otrs-megoldasok.hu
+# Copyright (C) 2015-2017 BeOnUp http://www.beonup.com.br
+# Copyright (C) 2016-2017 Balázs Úr, http://www.otrs-megoldasok.hu
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (AGPL). If you
@@ -28,6 +28,11 @@ sub Data {
     $Lang->{'Easy categorization for the service.'} = 'A szolgáltatás egyszerű kategorizálása.';
     $Lang->{'Easy categorization for the type.'} = 'A típus egyszerű kategorizálása.';
     $Lang->{'Easy categorization for the priority.'} = 'A prioritás egyszerű kategorizálása.';
+    $Lang->{'Frontend module registration for the agent interface.'} =
+        'Előtétprogram-modul regisztráció az ügyintézői felülethez.';
+    $Lang->{'To perform easy categorization with AJAX-request.'} =
+        'Az egyszerű kategorizálás végrehajtásához AJAX kéréssel.';
+    $Lang->{'EasyCategorization AJAX'} = 'Egyszerű kategorizálás AJAX';
 
     return 1;
 }

--- a/Kernel/Language/pt_BR_EasyCategorization.pm
+++ b/Kernel/Language/pt_BR_EasyCategorization.pm
@@ -1,6 +1,6 @@
 # --
 # Kernel/Language/pt_BR_EasyCategorization.pm - the Portuguese translation for EasyCategorization
-# Copyright (C) 2015-2016 BeOnUp http://www.beonup.com.br
+# Copyright (C) 2015-2017 BeOnUp http://www.beonup.com.br
 # --
 # This software comes with ABSOLUTELY NO WARRANTY. For details, see
 # the enclosed file COPYING for license information (AGPL). If you
@@ -27,6 +27,9 @@ sub Data {
     $Lang->{'Easy categorization for the service.'} = 'Serviço na categorização fácil.';
     $Lang->{'Easy categorization for the type.'} = 'Tipo na categorização fácil.';
     $Lang->{'Easy categorization for the priority.'} = 'Prioridade na categorização fácil.';
+    $Lang->{'Frontend module registration for the agent interface.'} = '';
+    $Lang->{'To perform easy categorization with AJAX-request.'} = '';
+    $Lang->{'EasyCategorization AJAX'} = '';
 
     return 1;
 }

--- a/Kernel/Output/HTML/OutputFilter/AgentEasyCategorization.pm
+++ b/Kernel/Output/HTML/OutputFilter/AgentEasyCategorization.pm
@@ -27,17 +27,17 @@ sub Run {
     my ( $Self, %Param ) = @_;
 
     # get needed objects
-    my $LayoutObject = $Kernel::OM->Get('Kernel::Output::HTML::Layout');
-    my $TicketObject = $Kernel::OM->Get('Kernel::System::Ticket');
-    my $ConfigObject = $Kernel::OM->Get('Kernel::Config');
-    my $ParamObject  = $Kernel::OM->Get('Kernel::System::Web::Request');
-	my $EasyCategorizationObject = $Kernel::OM->Get('Kernel::System::EasyCategorization');
+    my $LayoutObject             = $Kernel::OM->Get('Kernel::Output::HTML::Layout');
+    my $TicketObject             = $Kernel::OM->Get('Kernel::System::Ticket');
+    my $ConfigObject             = $Kernel::OM->Get('Kernel::Config');
+    my $ParamObject              = $Kernel::OM->Get('Kernel::System::Web::Request');
+    my $EasyCategorizationObject = $Kernel::OM->Get('Kernel::System::EasyCategorization');
 
     my %Ticket = $TicketObject->TicketGet(
         TicketID      => $Self->{TicketID},
         DynamicFields => 1,
         UserID        => $Self->{UserID},
-        Silent        => 1, 
+        Silent        => 1,
     );
 
     # get ACL restrictions
@@ -65,15 +65,15 @@ sub Run {
     {
         $GetParam{$Key} = $ParamObject->GetParam( Param => $Key );
     }
-	
-	# data structure
+
+    # data structure
     my %Data;
 
     if ( $ConfigObject->Get('EasyCategorization::Type') ){
         my $Types = $EasyCategorizationObject->GetTypeList(
             %GetParam,
             TicketID => $Self->{TicketID},
-			UserID   => $Self->{UserID}
+            UserID   => $Self->{UserID},
         );
 
         $Data{TypeStrg} = $LayoutObject->BuildSelection(
@@ -101,14 +101,14 @@ sub Run {
             TicketID       => $Self->{TicketID},
             CustomerUserID => $Ticket{CustomerUserID},
             QueueID        => $Ticket{QueueID},
-			Action		   => $Self->{Action}
+            Action         => $Self->{Action},
         );
 
         my $SLAs = $EasyCategorizationObject->GetSLAList(
             %GetParam,
             QueueID        => $Ticket{QueueID},
             ServiceID      => $Ticket{ServiceID},
-            CustomerUserID => $Ticket{CustomerUserID}
+            CustomerUserID => $Ticket{CustomerUserID},
         );
 
         $Data{ServiceSrtg} = $LayoutObject->BuildSelection(
@@ -150,8 +150,8 @@ sub Run {
         my $Priorities = $EasyCategorizationObject->GetPriorityList(
             %GetParam,
             TicketID => $Self->{TicketID},
-			Action	 => $Self->{Action},
-			UserID   => $Self->{UserID},
+            Action   => $Self->{Action},
+            UserID   => $Self->{UserID},
         );
 
         $Data{PriorityStrg} = $LayoutObject->BuildSelection(
@@ -177,48 +177,48 @@ sub Run {
         Data         => \%Data,
     );
     ${ $Param{Data} } =~ s{(<div \s+ id="ArticleTree">)}{$Frame $1}xms;
-	
-	#Load JS time execution
-	my $ZoomFrontendConfiguration = $ConfigObject->Get('Frontend::Module')->{AgentTicketZoom};
+
+    #Load JS time execution
+    my $ZoomFrontendConfiguration = $ConfigObject->Get('Frontend::Module')->{AgentTicketZoom};
     my @CustomJSFiles = ('Core.Agent.EasyCategorization.js');
     push( @{ $ZoomFrontendConfiguration->{Loader}->{JavaScript} || [] }, @CustomJSFiles );
-	
+
     # add js function to TypeID
-	my $JSBlock = <<"JS_TYPE_BLOCK";
+    my $JSBlock = <<"JS_TYPE_BLOCK";
 \$("#TypeID").bind('change', function () {
-	\$("#AJAXLoaderTypeID").css("display","");
-	
-	// Update Type and load Services data
+    \$("#AJAXLoaderTypeID").css("display","");
+
+    // Update Type and load Services data
     Core.Agent.EasyCategorization.TypeUpdate($Self->{TicketID});
 });
 JS_TYPE_BLOCK
-	
-	# add js function to ServiceID
-	$JSBlock .= <<"JS_SERVICE_BLOCK";
+
+    # add js function to ServiceID
+    $JSBlock .= <<"JS_SERVICE_BLOCK";
 \$("#ServiceID").bind('change', function () {
-	\$("#AJAXLoaderServiceID").css("display","");
-	
-	// Update service and load SLA data based
+    \$("#AJAXLoaderServiceID").css("display","");
+
+    // Update service and load SLA data based
     Core.Agent.EasyCategorization.ServiceUpdate($Self->{TicketID});
 });
 JS_SERVICE_BLOCK
 
-	# add js function to SLAID
-	$JSBlock .= <<"JS_SLA_BLOCK";
+    # add js function to SLAID
+    $JSBlock .= <<"JS_SLA_BLOCK";
 \$("#SLAID").bind('change', function () {
-	\$("#AJAXLoaderSLAID").css("display","");
+    \$("#AJAXLoaderSLAID").css("display","");
 
-	// Set value to SLA
+    // Set value to SLA
     Core.Agent.EasyCategorization.SLAUpdate($Self->{TicketID});
 });
 JS_SLA_BLOCK
 
-	# add js function to PriorityID
-	$JSBlock .= <<"JS_PRIORITY_BLOCK";
+    # add js function to PriorityID
+    $JSBlock .= <<"JS_PRIORITY_BLOCK";
 \$("#PriorityID").bind('change', function () {
-	\$("#AJAXLoaderPriorityID").css("display","");
-	
-	// Set value to Priority
+    \$("#AJAXLoaderPriorityID").css("display","");
+
+    // Set value to Priority
     Core.Agent.EasyCategorization.PriorityUpdate($Self->{TicketID});
 });
 JS_PRIORITY_BLOCK

--- a/Kernel/Output/HTML/Templates/Standard/AgentEasyCategorization.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AgentEasyCategorization.tt
@@ -9,27 +9,35 @@
 <div class="WidgetSimple SpacingTop Expanded">
     <div class="Header">
         <div class="WidgetAction Toggle">
-            <a href="#" title="[% Translate("Toggle this widget") | html %]"><i class="fa fa-caret-right"></i><i class="fa fa-caret-down"></i></a>
+            <a href="#" title="[% Translate("Show or hide the content") | html %]"><i class="fa fa-caret-right"></i><i class="fa fa-caret-down"></i></a>
         </div>
         <h2>[% Translate("Easy Categorization") | html %]</h2>
     </div>
     <div class="Content">
-		<fieldset class="TableLike">            
+        <fieldset class="TableLike">
             <div class="Field" style="margin-left: 0%;">
-				<label for="TypeID">[% Translate("Type") | html %]:</label>
-				[% Data.TypeStrg %]
-				<span id="AJAXLoaderTypeID" class="AJAXLoader" style="display: none;"></span>
-				<label for="ServiceID">[% Translate("Service") | html %]:</label>
-				[% Data.ServiceSrtg %]
-				<span id="AJAXLoaderServiceID" class="AJAXLoader" style="display: none;"></span>
-				<label for="SLAID">[% Translate("SLA") | html %]:</label>
-				[% Data.SLAStrg %]
-				<span id="AJAXLoaderSLAID" class="AJAXLoader" style="display: none;"></span>
-				<label for="PriorityID">[% Translate("Priority") | html %]:</label>
-				[% Data.PriorityStrg %]
-				<span id="AJAXLoaderPriorityID" class="AJAXLoader" style="display: none;"></span>
+[% RenderBlockStart("Type") %]
+                <label for="TypeID">[% Translate("Type") | html %]:</label>
+                [% Data.TypeStrg %]
+                <span id="AJAXLoaderTypeID" class="AJAXLoader" style="display: none;"></span>
+[% RenderBlockEnd("Type") %]
+[% RenderBlockStart("Service") %]
+                <label for="ServiceID">[% Translate("Service") | html %]:</label>
+                [% Data.ServiceSrtg %]
+                <span id="AJAXLoaderServiceID" class="AJAXLoader" style="display: none;"></span>
+[% RenderBlockEnd("Service") %]
+[% RenderBlockStart("SLA") %]
+                <label for="SLAID">[% Translate("SLA") | html %]:</label>
+                [% Data.SLAStrg %]
+                <span id="AJAXLoaderSLAID" class="AJAXLoader" style="display: none;"></span>
+[% RenderBlockEnd("SLA") %]
+[% RenderBlockStart("Priority") %]
+                <label for="PriorityID">[% Translate("Priority") | html %]:</label>
+                [% Data.PriorityStrg %]
+                <span id="AJAXLoaderPriorityID" class="AJAXLoader" style="display: none;"></span>
+[% RenderBlockEnd("Priority") %]
             </div>
             <div class="Clear"></div>
-		</fieldset>
-	</div>
+        </fieldset>
+    </div>
 </div>

--- a/Kernel/System/EasyCategorization.pm
+++ b/Kernel/System/EasyCategorization.pm
@@ -17,7 +17,7 @@ use warnings;
 our @ObjectDependencies = (
     'Kernel::Config',
     'Kernel::System::Ticket',
-	'Ticket::Service::Default::UnknownCustomer'
+    'Ticket::Service::Default::UnknownCustomer'
 );
 
 sub new {
@@ -49,10 +49,10 @@ sub GetServiceList {
     if ( $Param{CustomerUserID} && $Param{Action} ) {
         %Service = $Kernel::OM->Get('Kernel::System::Ticket')->TicketServiceList(
             %Param,
-			Action => $Param{Action} || 'AgentTicketZoom',
+            Action => $Param{Action} || 'AgentTicketZoom',
         );
     }
-	
+
     return \%Service;
 }
 
@@ -99,14 +99,14 @@ sub GetTypeList {
 
 sub GetPriorityList {
     my ( $Self, %Param ) = @_;
-	
-	my %Priorities;
-	if ( $Param{Action} || $Param{TicketID} ) {
+
+    my %Priorities;
+    if ( $Param{Action} || $Param{TicketID} ) {
         %Priorities = $Kernel::OM->Get('Kernel::System::Ticket')->TicketPriorityList(
-			%Param,
-			Action   => $Param{Action},
-			TicketID => $Param{TicketID},
-		);
+            %Param,
+            Action   => $Param{Action},
+            TicketID => $Param{TicketID},
+        );
     }
 
     # get config of frontend module
@@ -117,6 +117,5 @@ sub GetPriorityList {
     }
     return \%Priorities;
 }
-
 
 1;

--- a/var/httpd/htdocs/js/Core.Agent.EasyCategorization.js
+++ b/var/httpd/htdocs/js/Core.Agent.EasyCategorization.js
@@ -20,9 +20,9 @@ var Core = Core || {};
  * @description
  *      This namespace contains the special module functions for EasyCategorization.
  */
-Core.Agent.EasyCategorization = (function (TargetNS) {  
-    
-	/**
+Core.Agent.EasyCategorization = (function (TargetNS) {
+
+    /**
      * @name TypeUpdate
      * @memberof Core.Agent.EasyCategorization
      * @function
@@ -30,37 +30,37 @@ Core.Agent.EasyCategorization = (function (TargetNS) {
      * @description
      *      This function gets service data.
      */
-	
-	TargetNS.TypeUpdate = function (TicketID) {
+
+    TargetNS.TypeUpdate = function (TicketID) {
         var Data = {
             Action: 'EasyCategorizationAJAXHandler',
             Subaction: 'TypeUpdate',
-			TypeID: $('#TypeID').val(),
-			TicketID: TicketID,
+            TypeID: $('#TypeID').val(),
+            TicketID: TicketID,
         };
-		
-		Core.AJAX.FunctionCall(Core.Config.Get('CGIHandle'), Data, function (Result) {						
-			if (!Result){
-				Core.Exception.HandleFinalError(new Core.Exception.ApplicationError("Error! No server response.", 'CommunicationError'));
-			}
-			else{
-				var SelectData = JSON.parse(Result.JSONString);
-				
-				UpdateFormElements(SelectData);
-				
-				$("#AJAXLoaderTypeID").css("display", "none");
-				
-				if ($('#ServiceID option').length == 1) {
-					$('#ServiceID').attr("readonly", "true");
-				}
-				else{
-					$('#ServiceID').attr("readonly", "false");
-				}
-			}
-		}); 
-	}
-	
-	/**
+
+        Core.AJAX.FunctionCall(Core.Config.Get('CGIHandle'), Data, function (Result) {
+            if (!Result) {
+                Core.Exception.HandleFinalError(new Core.Exception.ApplicationError("Error! No server response.", 'CommunicationError'));
+            }
+            else {
+                var SelectData = JSON.parse(Result.JSONString);
+
+                UpdateFormElements(SelectData);
+
+                $("#AJAXLoaderTypeID").css("display", "none");
+
+                if ($('#ServiceID option').length == 1) {
+                    $('#ServiceID').attr("readonly", "true");
+                }
+                else{
+                    $('#ServiceID').attr("readonly", "false");
+                }
+            }
+        });
+    }
+
+    /**
      * @name ServiceUpdate
      * @memberof Core.Agent.EasyCategorization
      * @function
@@ -68,36 +68,36 @@ Core.Agent.EasyCategorization = (function (TargetNS) {
      * @description
      *      This function gets service data.
      */
-	 
-	TargetNS.ServiceUpdate = function (TicketID) {
+
+    TargetNS.ServiceUpdate = function (TicketID) {
         var Data = {
             Action: 'EasyCategorizationAJAXHandler',
             Subaction: 'ServiceUpdate',
-			ServiceID: $('#ServiceID').val(),
-			TicketID: TicketID,
+            ServiceID: $('#ServiceID').val(),
+            TicketID: TicketID,
         };
-		
-		Core.AJAX.FunctionCall(Core.Config.Get('CGIHandle'), Data, function (Result) {						
-			if (!Result){
-				Core.Exception.HandleFinalError(new Core.Exception.ApplicationError("Error! No server response.", 'CommunicationError'));
-			}
-			else{
-				var SelectData = JSON.parse(Result.JSONString);
-				UpdateFormElements(SelectData);
-				$("#AJAXLoaderServiceID").css("display", "none");
-				
-				if ($('#SLAID option').length == 1) {
-					$('#SLAID').attr("readonly", "true");
-				}
-				else{
-					$('#SLAID_Search').attr("readonly", false);
-					$('#SLAID').attr("readonly", false);
-				}
-			}
-		}); 
-	}
-	
-	/**
+
+        Core.AJAX.FunctionCall(Core.Config.Get('CGIHandle'), Data, function (Result) {
+            if (!Result){
+                Core.Exception.HandleFinalError(new Core.Exception.ApplicationError("Error! No server response.", 'CommunicationError'));
+            }
+            else{
+                var SelectData = JSON.parse(Result.JSONString);
+                UpdateFormElements(SelectData);
+                $("#AJAXLoaderServiceID").css("display", "none");
+
+                if ($('#SLAID option').length == 1) {
+                    $('#SLAID').attr("readonly", "true");
+                }
+                else{
+                    $('#SLAID_Search').attr("readonly", false);
+                    $('#SLAID').attr("readonly", false);
+                }
+            }
+        });
+    }
+
+    /**
      * @name SLAUpdate
      * @memberof Core.Agent.EasyCategorization
      * @function
@@ -105,26 +105,26 @@ Core.Agent.EasyCategorization = (function (TargetNS) {
      * @description
      *      This function gets service data.
      */
-	
-	TargetNS.SLAUpdate = function (TicketID) {
+
+    TargetNS.SLAUpdate = function (TicketID) {
         var Data = {
             Action: 'EasyCategorizationAJAXHandler',
             Subaction: 'SLAUpdate',
-			SLAID: $('#SLAID').val(),
-			TicketID: TicketID,
+            SLAID: $('#SLAID').val(),
+            TicketID: TicketID,
         };
-		
-		Core.AJAX.FunctionCall(Core.Config.Get('CGIHandle'), Data, function (Result) {
-			if (!Result){
-				Core.Exception.HandleFinalError(new Core.Exception.ApplicationError("Error! No server response.", 'CommunicationError'));
-			}
-			else{
-				$("#AJAXLoaderSLAID").css("display", "none");
-			}
-		}); 
-	}
-	
-	/**
+
+        Core.AJAX.FunctionCall(Core.Config.Get('CGIHandle'), Data, function (Result) {
+            if (!Result){
+                Core.Exception.HandleFinalError(new Core.Exception.ApplicationError("Error! No server response.", 'CommunicationError'));
+            }
+            else{
+                $("#AJAXLoaderSLAID").css("display", "none");
+            }
+        });
+    }
+
+    /**
      * @name PriorityUpdate
      * @memberof Core.Agent.EasyCategorization
      * @function
@@ -132,26 +132,26 @@ Core.Agent.EasyCategorization = (function (TargetNS) {
      * @description
      *      This function gets service data.
      */
-	
-	TargetNS.PriorityUpdate = function (TicketID) {
+
+    TargetNS.PriorityUpdate = function (TicketID) {
         var Data = {
             Action: 'EasyCategorizationAJAXHandler',
             Subaction: 'PriorityUpdate',
-			PriorityID: $('#PriorityID').val(),
-			TicketID: TicketID,
+            PriorityID: $('#PriorityID').val(),
+            TicketID: TicketID,
         };
-		
-		Core.AJAX.FunctionCall(Core.Config.Get('CGIHandle'), Data, function (Result) {
-			if (!Result){
-				Core.Exception.HandleFinalError(new Core.Exception.ApplicationError("Error! No server response.", 'CommunicationError'));
-			}
-			else{
-				$("#AJAXLoaderPriorityID").css("display", "none");
-			}
-		});
-	}
-	
-	/**
+
+        Core.AJAX.FunctionCall(Core.Config.Get('CGIHandle'), Data, function (Result) {
+            if (!Result){
+                Core.Exception.HandleFinalError(new Core.Exception.ApplicationError("Error! No server response.", 'CommunicationError'));
+            }
+            else{
+                $("#AJAXLoaderPriorityID").css("display", "none");
+            }
+        });
+    }
+
+    /**
      * @private
      * @name UpdateFormElements
      * @function
@@ -159,35 +159,35 @@ Core.Agent.EasyCategorization = (function (TargetNS) {
      * @description
      *      Updates the given fields with the given data.
      */
-	 
-	function UpdateFormElements(Data) {
-		$.each(Data, function (Field, DataValue) {
-			var $Element = $('#' + Field);
-			// Select elements
-			if ($Element.is('select')) {
-				$Element.empty();
-				$.each(DataValue, function (Index, Value) {
-					var NewOption,
-						OptionText = Core.App.EscapeHTML(Value[1]);
-			
-					NewOption = new Option(OptionText, Value[0], Value[2], Value[3]);
-			
-					// Overwrite option text, because of wrong html quoting of text content.
-					// (This is needed for IE.)
-					NewOption.innerHTML = OptionText;
-					$Element.append(NewOption);
-			
-				});
-			
-				// Trigger custom redraw event for InputFields
-				if ($Element.hasClass('Modernize')) {
-					$Element.trigger('redraw.InputField');
-				}
-			
-				return;
-			}
-		});
-	}
+
+    function UpdateFormElements(Data) {
+        $.each(Data, function (Field, DataValue) {
+            var $Element = $('#' + Field);
+            // Select elements
+            if ($Element.is('select')) {
+                $Element.empty();
+                $.each(DataValue, function (Index, Value) {
+                    var NewOption,
+                        OptionText = Core.App.EscapeHTML(Value[1]);
+
+                    NewOption = new Option(OptionText, Value[0], Value[2], Value[3]);
+
+                    // Overwrite option text, because of wrong html quoting of text content.
+                    // (This is needed for IE.)
+                    NewOption.innerHTML = OptionText;
+                    $Element.append(NewOption);
+
+                });
+
+                // Trigger custom redraw event for InputFields
+                if ($Element.hasClass('Modernize')) {
+                    $Element.trigger('redraw.InputField');
+                }
+
+                return;
+            }
+        });
+    }
 
     return TargetNS;
 }(Core.Agent.EasyCategorization || {}));


### PR DESCRIPTION
Hi @joserribeiro26 
This PR contains the following changes:
- hide disabled Service, Type and Priority from the widget
- remove change log from .sopm (the reason is, that here the commit log contains it, and the change log in the .sopm is displayed in the package manger, and it is not translatable)
- marked new strings as translatable and added to language files (pt_BR needs to be translated)
- code cleanup (replaced TABs with spaces)
- updated version number, so it is ready to release